### PR TITLE
Use postgres engine in `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 server_ip="127.0.0.1"
-engine="django.db.backends.sqlite3"
+engine="django.db.backends.postgresql_psycopg"
 host="127.0.0.1"
 db="testdb"
 usr="testuser"

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 server_ip="127.0.0.1"
-engine="django.db.backends.postgresql_psycopg"
+engine="django.db.backends.postgresql"
 host="127.0.0.1"
 db="testdb"
 usr="testuser"


### PR DESCRIPTION
my goal is, that we can use the (unmodified) .env.example and use it to connect to a local postgres db with the given credentials
