### PR TITLE
Fix bug that sites could not be edited in admin view

### DIFF
--- a/wiki/admin.py
+++ b/wiki/admin.py
@@ -48,9 +48,13 @@ class ArticleAdmin(SimpleHistoryAdmin):
         This makes the response go to the newly created
         model's change page without using reverse
         """
-        _, redirect_page = request.get_full_path().split("?next=")
+        full_path = request.get_full_path()
+        if "?next=" in full_path:
+            _, redirect_page = request.get_full_path().split("?next=")
+            return HttpResponseRedirect(redirect_page)
+        else:
+            return super(ArticleAdmin, self).response_change(request, obj)
 
-        return HttpResponseRedirect(redirect_page)
 
 
 admin.site.register(Image)

--- a/wiki/admin.py
+++ b/wiki/admin.py
@@ -56,7 +56,6 @@ class ArticleAdmin(SimpleHistoryAdmin):
             return super(ArticleAdmin, self).response_change(request, obj)
 
 
-
 admin.site.register(Image)
 admin.site.register(Category)
 admin.site.register(Display)


### PR DESCRIPTION
Reason was that the internal page path was split into original path and redirect path, without testing if the redirect statement was included at all. Now it is a conditional, that defaults to the behavior of the parent class if no redirect is present